### PR TITLE
Missing path for include_search

### DIFF
--- a/cinder/nav.html
+++ b/cinder/nav.html
@@ -42,7 +42,7 @@
             {% endif %}
 
             <ul class="nav navbar-nav navbar-right">
-                {% if include_search %}
+                {% if config.extra.include_search %}
                     <li>
                         <a href="#" data-toggle="modal" data-target="#mkdocs_search_modal">
                             <i class="fa fa-search"></i> Search


### PR DESCRIPTION
I noticed that the search was permanently disabled. This fixes it.  I am not too familiar with the framework so not sure if config.extra presence needs to be checked